### PR TITLE
passing GitHub OAuth token in header

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -35,7 +35,7 @@ create_gh_deployment () {
     curl -s -X POST "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/deployments" \
       -H 'Content-Type: application/json' \
       -H 'Accept: application/vnd.github.ant-man-preview+json' \
-      -u ${GITHUB_ACCESS_TOKEN} \
+      -u "waffle-cicd-bot:${GITHUB_ACCESS_TOKEN}" \
       -d "$(gh_deployment_create_body)"
   fi
 }
@@ -50,7 +50,7 @@ notify_gh_about_a_deployment () {
     curl -s -X POST "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/deployments/${deployment_id}/statuses" \
       -H 'Content-Type: application/json' \
       -H 'Accept: application/vnd.github.ant-man-preview+json' \
-      -u ${GITHUB_ACCESS_TOKEN} \
+      -u "waffle-cicd-bot:${GITHUB_ACCESS_TOKEN}" \
       -d "$(gh_deployment_notify_body $deployment_status)" > /dev/null
   fi
 }


### PR DESCRIPTION
_This is the only PR of the three on this card that needs to be merged. The other 2 PRs are only for demonstration purposes that this worked._

You can see that this worked on these two PRs:
1. https://github.com/waffleio/waffle.io-app/pull/2047
1. https://github.com/waffleio/waffle.io-api/pull/381

What I did:
1. Created a new machine user in GitHub named `waffle-cicd-bot`. I also added documentation around that user to [the tribal knowledge deployments page](https://github.com/waffleio/tribal-knowledge/wiki/Deployment#waffle-cicd-bot).
1. Change deploy.sh to use a personal access token owned by that user.
1. Updated the environment variables in all the Circle jobs to use the new token owned by the machine user.
1. Updated the tags in Quay to point to the new node-builder images with this change. This means that all the repos will pick up on the change with their next build.

connect https://github.com/waffleio/hidden/issues/345